### PR TITLE
LW-33786: scrub sensitive data from Sentry events before send

### DIFF
--- a/spec/Sentry/SensitiveDataScrubberSpec.php
+++ b/spec/Sentry/SensitiveDataScrubberSpec.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace spec\Lingoda\SentryBundle\Sentry;
+
+use Lingoda\SentryBundle\DependencyInjection\Configuration;
+use Lingoda\SentryBundle\Sentry\SensitiveDataScrubber;
+use PhpSpec\ObjectBehavior;
+use RuntimeException;
+use Sentry\Breadcrumb;
+use Sentry\Event;
+use Sentry\ExceptionDataBag;
+use Sentry\Frame;
+use Sentry\Stacktrace;
+
+class SensitiveDataScrubberSpec extends ObjectBehavior
+{
+    public function let(): void
+    {
+        $this->beConstructedWith(
+            Configuration::DEFAULT_QUERY_PARAM_NAMES,
+            Configuration::DEFAULT_VALUE_PATTERNS,
+        );
+    }
+
+    public function it_is_initializable(): void
+    {
+        $this->shouldHaveType(SensitiveDataScrubber::class);
+    }
+
+    public function it_filters_query_string_secret_from_url(): void
+    {
+        $value = 'https://example.com/v1/foo?key=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567&page=2#frag';
+
+        $this->scrub($value)
+            ->shouldBe('https://example.com/v1/foo?key=[Filtered]&page=2#frag');
+    }
+
+    public function it_filters_multiple_known_query_param_names(): void
+    {
+        foreach (['key', 'api_key', 'apikey', 'access_token', 'token', 'secret', 'password', 'auth', 'signature'] as $name) {
+            $input = "https://example.com/?$name=hunter2";
+            $this->scrub($input)
+                ->shouldBe("https://example.com/?$name=[Filtered]");
+        }
+    }
+
+    public function it_matches_query_param_names_case_insensitively(): void
+    {
+        $this->scrub('https://example.com/?Key=abc')
+            ->shouldBe('https://example.com/?Key=[Filtered]');
+    }
+
+    public function it_leaves_non_sensitive_query_params_intact(): void
+    {
+        $value = 'https://example.com/v1/foo?page=2&order=desc&user_id=42';
+
+        $this->scrub($value)->shouldBe($value);
+    }
+
+    public function it_preserves_url_scheme_host_path_and_fragment(): void
+    {
+        $value = 'https://user.example.com:8443/some/path?key=SECRET&other=ok#section';
+
+        $this->scrub($value)
+            ->shouldBe('https://user.example.com:8443/some/path?key=[Filtered]&other=ok#section');
+    }
+
+    public function it_filters_google_api_key_pattern_in_free_text(): void
+    {
+        $this->scrub('Failed with key AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567 in handler')
+            ->shouldEndWith(' in handler');
+
+        $this->scrub('AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567')
+            ->shouldBe('[Filtered]');
+    }
+
+    public function it_filters_stripe_secret_key_pattern(): void
+    {
+        $this->scrub('sk_live_abcdefghijklmnop')->shouldBe('[Filtered]');
+        $this->scrub('sk_test_ZYXWVUTSRQPONMLK')->shouldBe('[Filtered]');
+    }
+
+    public function it_filters_bearer_token_pattern(): void
+    {
+        $this->scrub('Bearer abc.DEF-ghi_jkl/mno+pqr=')->shouldBe('[Filtered]');
+    }
+
+    public function it_filters_jwt_pattern(): void
+    {
+        $jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+        $this->scrub($jwt)->shouldBe('[Filtered]');
+    }
+
+    public function it_leaves_non_credential_strings_alone(): void
+    {
+        $this->scrub('the quick brown fox jumps over the lazy dog')
+            ->shouldBe('the quick brown fox jumps over the lazy dog');
+
+        $this->scrub('user@example.com')->shouldBe('user@example.com');
+    }
+
+    public function it_filters_known_query_params_from_exception_message(): void
+    {
+        $event = Event::createEvent();
+        $message = 'HTTP/2 403 returned for "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent?key=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567"';
+        $event->setExceptions([new ExceptionDataBag(new RuntimeException($message))]);
+
+        $this->__invoke($event)
+            ->shouldHaveExceptionValue(
+                'HTTP/2 403 returned for "https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent?key=[Filtered]"'
+            );
+    }
+
+    public function it_filters_request_url_and_query_string(): void
+    {
+        $event = Event::createEvent();
+        $event->setRequest([
+            'url' => 'https://api.example.com/v1/things?api_key=secret123&page=2',
+            'query_string' => 'api_key=secret123&page=2',
+        ]);
+
+        $this->__invoke($event)->shouldHaveRequestKey('url', 'https://api.example.com/v1/things?api_key=[Filtered]&page=2');
+        $this->__invoke($event)->shouldHaveRequestKey('query_string', 'api_key=[Filtered]&page=2');
+    }
+
+    public function it_filters_query_params_in_breadcrumb_message_and_url(): void
+    {
+        $event = Event::createEvent();
+        $event->setBreadcrumb([
+            new Breadcrumb(
+                Breadcrumb::LEVEL_INFO,
+                Breadcrumb::TYPE_HTTP,
+                'http',
+                'GET https://api.example.com/?token=abc',
+                ['url' => 'https://api.example.com/?token=abc'],
+            ),
+        ]);
+
+        $this->__invoke($event)->shouldHaveBreadcrumbMessage(0, 'GET https://api.example.com/?token=[Filtered]');
+        $this->__invoke($event)->shouldHaveBreadcrumbMetadata(0, 'url', 'https://api.example.com/?token=[Filtered]');
+    }
+
+    public function it_filters_string_values_in_frame_vars(): void
+    {
+        $event = Event::createEvent();
+        $frame = new Frame(
+            'callApi',
+            'src/Foo.php',
+            42,
+            null,
+            null,
+            ['url' => 'https://example.com/?key=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567', 'count' => 7],
+        );
+        $event->setExceptions([
+            new ExceptionDataBag(new RuntimeException('boom'), new Stacktrace([$frame])),
+        ]);
+
+        $this->__invoke($event)->shouldHaveFrameVar(0, 'url', 'https://example.com/?key=[Filtered]');
+        $this->__invoke($event)->shouldHaveFrameVar(0, 'count', 7);
+    }
+
+    public function it_does_not_recurse_into_frame_vars_past_max_depth(): void
+    {
+        $event = Event::createEvent();
+        $secret = 'AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567';
+        $deepVars = ['a' => ['b' => ['c' => ['d' => $secret]]]];
+        $frame = new Frame('deep', 'src/Foo.php', 1, null, null, $deepVars);
+        $event->setExceptions([
+            new ExceptionDataBag(new RuntimeException('boom'), new Stacktrace([$frame])),
+        ]);
+
+        $this->__invoke($event)->shouldHaveDeepFrameValue($secret);
+    }
+
+    public function it_passes_through_when_event_is_empty(): void
+    {
+        $event = Event::createEvent();
+
+        $this->__invoke($event)->shouldReturnAnInstanceOf(Event::class);
+    }
+
+    public function it_filters_event_message_set_via_capture_message(): void
+    {
+        $event = Event::createEvent();
+        $event->setMessage(
+            'Upstream call failed: https://api.example.com/v1/x?api_key=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567',
+            ['AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567'],
+            'Upstream call failed: https://api.example.com/v1/x?api_key=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567',
+        );
+
+        $scrubbed = $this->__invoke($event);
+        $scrubbed->shouldHaveEventMessage('Upstream call failed: https://api.example.com/v1/x?api_key=[Filtered]');
+        $scrubbed->shouldHaveEventMessageFormatted('Upstream call failed: https://api.example.com/v1/x?api_key=[Filtered]');
+        $scrubbed->shouldHaveEventMessageParam(0, '[Filtered]');
+    }
+
+    public function it_filters_authorization_header_value(): void
+    {
+        $event = Event::createEvent();
+        $event->setRequest([
+            'url' => 'https://api.example.com/v1/things',
+            'headers' => [
+                'Authorization' => ['Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U'],
+                'X-Request-Id' => ['abc-123'],
+            ],
+        ]);
+
+        $scrubbed = $this->__invoke($event);
+        $scrubbed->shouldHaveRequestHeader('Authorization', 0, '[Filtered]');
+        $scrubbed->shouldHaveRequestHeader('X-Request-Id', 0, 'abc-123');
+    }
+
+    public function it_filters_lowercase_bearer_in_header_dumps(): void
+    {
+        $message = 'Got: authorization: bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U';
+        $this->scrub($message)
+            ->shouldBe('Got: authorization: [Filtered]');
+    }
+
+    public function it_does_not_eat_english_text_containing_bearer(): void
+    {
+        $this->scrub('This is not a Bearer of tokens')
+            ->shouldBe('This is not a Bearer of tokens');
+    }
+
+    public function it_filters_credentials_in_request_data_and_cookies(): void
+    {
+        $event = Event::createEvent();
+        $event->setRequest([
+            'cookies' => ['session' => 'sk_live_abcdefghijklmnop'],
+            'data' => ['payload' => ['inner' => 'AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567']],
+        ]);
+
+        $scrubbed = $this->__invoke($event);
+        $scrubbed->shouldHaveRequestNested('cookies', ['session'], '[Filtered]');
+        $scrubbed->shouldHaveRequestNested('data', ['payload', 'inner'], '[Filtered]');
+    }
+
+    public function it_filters_query_string_in_breadcrumb_http_query_metadata(): void
+    {
+        $event = Event::createEvent();
+        $event->setBreadcrumb([
+            new Breadcrumb(
+                Breadcrumb::LEVEL_INFO,
+                Breadcrumb::TYPE_HTTP,
+                'http',
+                null,
+                [
+                    'url' => 'https://api.example.com/v1/items',
+                    'http.query' => 'api_key=AIzaSyAbCdEfGhIjKlMnOpQrStUvWxYz1234567&page=2',
+                    'http.request.method' => 'GET',
+                ],
+            ),
+        ]);
+
+        $scrubbed = $this->__invoke($event);
+        $scrubbed->shouldHaveBreadcrumbMetadata(0, 'http.query', 'api_key=[Filtered]&page=2');
+        $scrubbed->shouldHaveBreadcrumbMetadata(0, 'http.request.method', 'GET');
+    }
+
+    public function it_rejects_invalid_value_patterns_at_construction(): void
+    {
+        $this->beConstructedWith(Configuration::DEFAULT_QUERY_PARAM_NAMES, ['#unterminated(#']);
+        $this->shouldThrow(\Throwable::class)->duringInstantiation();
+    }
+
+    /**
+     * @return array<string, callable>
+     */
+    public function getMatchers(): array
+    {
+        return [
+            'haveExceptionValue' => static fn (Event $subject, string $expected): bool =>
+                ($subject->getExceptions()[0] ?? null)?->getValue() === $expected,
+            'haveEventMessage' => static fn (Event $subject, string $expected): bool =>
+                $subject->getMessage() === $expected,
+            'haveEventMessageFormatted' => static fn (Event $subject, string $expected): bool =>
+                $subject->getMessageFormatted() === $expected,
+            'haveEventMessageParam' => static fn (Event $subject, int $i, string $expected): bool =>
+                ($subject->getMessageParams()[$i] ?? null) === $expected,
+            'haveRequestKey' => static function (Event $subject, string $key, string $expected): bool {
+                $request = $subject->getRequest();
+                return ($request[$key] ?? null) === $expected;
+            },
+            'haveRequestHeader' => static function (Event $subject, string $name, int $i, string $expected): bool {
+                $headers = $subject->getRequest()['headers'] ?? null;
+                if (!is_array($headers) || !isset($headers[$name][$i])) {
+                    return false;
+                }
+                return $headers[$name][$i] === $expected;
+            },
+            'haveRequestNested' => static function (Event $subject, string $top, array $path, mixed $expected): bool {
+                $value = $subject->getRequest()[$top] ?? null;
+                foreach ($path as $k) {
+                    if (!is_array($value) || !array_key_exists($k, $value)) {
+                        return false;
+                    }
+                    $value = $value[$k];
+                }
+                return $value === $expected;
+            },
+            'haveBreadcrumbMessage' => static function (Event $subject, int $i, string $expected): bool {
+                $bc = $subject->getBreadcrumbs()[$i] ?? null;
+                return $bc instanceof Breadcrumb && $bc->getMessage() === $expected;
+            },
+            'haveBreadcrumbMetadata' => static function (Event $subject, int $i, string $key, string $expected): bool {
+                $bc = $subject->getBreadcrumbs()[$i] ?? null;
+                if (!$bc instanceof Breadcrumb) {
+                    return false;
+                }
+                return ($bc->getMetadata()[$key] ?? null) === $expected;
+            },
+            'haveFrameVar' => static function (Event $subject, int $i, string $key, mixed $expected): bool {
+                $stacktrace = ($subject->getExceptions()[0] ?? null)?->getStacktrace();
+                if ($stacktrace === null) {
+                    return false;
+                }
+                $frame = $stacktrace->getFrames()[$i] ?? null;
+                if (!$frame instanceof Frame) {
+                    return false;
+                }
+                return ($frame->getVars()[$key] ?? null) === $expected;
+            },
+            'haveDeepFrameValue' => static function (Event $subject, string $expected): bool {
+                $stacktrace = ($subject->getExceptions()[0] ?? null)?->getStacktrace();
+                if ($stacktrace === null) {
+                    return false;
+                }
+                $frame = $stacktrace->getFrames()[0] ?? null;
+                if (!$frame instanceof Frame) {
+                    return false;
+                }
+                $value = $frame->getVars();
+                foreach (['a', 'b', 'c', 'd'] as $key) {
+                    if (!is_array($value) || !array_key_exists($key, $value)) {
+                        return $value === $expected;
+                    }
+                    $value = $value[$key];
+                }
+                return $value === $expected;
+            },
+        ];
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,23 +9,76 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
+    public const DEFAULT_QUERY_PARAM_NAMES = [
+        'key',
+        'api_key',
+        'apikey',
+        'access_token',
+        'token',
+        'secret',
+        'password',
+        'auth',
+        'signature',
+    ];
+
+    public const DEFAULT_VALUE_PATTERNS = [
+        '#AIza[0-9A-Za-z\-_]{20,}#',
+        '#sk_(?:live|test)_[0-9a-zA-Z]{16,}#',
+        '#\bBearer\s+[A-Za-z0-9\-._~+/]{16,}=*#i',
+        '#\beyJ[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}\.[A-Za-z0-9_\-]{4,}\b#',
+    ];
+
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('lingoda_sentry');
 
         $treeBuilder->getRootNode()
             ->children()
-            ->scalarNode('dsn')->isRequired()->end()
-            ->scalarNode('environment')->isRequired()->end()
-            ->scalarNode('namespace')->defaultNull()->end()
-            ->scalarNode('release')->defaultValue('none')->end()
-            ->floatNode('traces_sample_rate')->defaultValue(0.0)->end()
-            ->arrayNode('json_serialize')->defaultValue([])
-            ->scalarPrototype()->end()
-            ->end()
-            ->arrayNode('namespace_serialize')->defaultValue([])
-            ->scalarPrototype()->end()
-            ->end()
+                ->scalarNode('dsn')->isRequired()->end()
+                ->scalarNode('environment')->isRequired()->end()
+                ->scalarNode('namespace')->defaultNull()->end()
+                ->scalarNode('release')->defaultValue('none')->end()
+                ->floatNode('traces_sample_rate')->defaultValue(0.0)->end()
+                ->scalarNode('before_send')
+                    ->defaultNull()
+                    ->info('Service ID of a callable __invoke(Event, ?EventHint): ?Event. Overrides the default SensitiveDataScrubber. Mirror upstream sentry-symfony: no @ prefix.')
+                ->end()
+                ->scalarNode('before_breadcrumb')
+                    ->defaultNull()
+                    ->info('Service ID of a callable __invoke(Breadcrumb, ?BreadcrumbHint): ?Breadcrumb. No @ prefix.')
+                ->end()
+                ->arrayNode('json_serialize')->defaultValue([])
+                    ->scalarPrototype()->end()
+                ->end()
+                ->arrayNode('namespace_serialize')->defaultValue([])
+                    ->scalarPrototype()->end()
+                ->end()
+                ->arrayNode('scrubber')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->booleanNode('enabled')->defaultTrue()->end()
+                        ->arrayNode('query_param_names')
+                            ->info('Query-string parameter names to redact (case-insensitive). Overrides defaults.')
+                            ->defaultValue(self::DEFAULT_QUERY_PARAM_NAMES)
+                            ->scalarPrototype()->end()
+                        ->end()
+                        ->arrayNode('extra_query_param_names')
+                            ->info('Extra query-string parameter names to redact in addition to the defaults.')
+                            ->defaultValue([])
+                            ->scalarPrototype()->end()
+                        ->end()
+                        ->arrayNode('value_patterns')
+                            ->info('PCRE patterns (delimited) for credential shapes. Overrides defaults.')
+                            ->defaultValue(self::DEFAULT_VALUE_PATTERNS)
+                            ->scalarPrototype()->end()
+                        ->end()
+                        ->arrayNode('extra_value_patterns')
+                            ->info('Extra PCRE patterns (delimited) to redact in addition to the defaults.')
+                            ->defaultValue([])
+                            ->scalarPrototype()->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/LingodaSentryExtension.php
+++ b/src/DependencyInjection/LingodaSentryExtension.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Lingoda\SentryBundle\DependencyInjection;
 
+use Lingoda\SentryBundle\Sentry\SensitiveDataScrubber;
 use Lingoda\SentryBundle\Sentry\Serializer\ObjectJsonSerializer;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -23,6 +24,24 @@ class LingodaSentryExtension extends ConfigurableExtension implements PrependExt
             __DIR__ . '/../Resources/config'
         ));
         $loader->load('services.yaml');
+
+        /** @var array{enabled: bool, query_param_names: list<string>, extra_query_param_names: list<string>, value_patterns: list<string>, extra_value_patterns: list<string>} $scrubber */
+        $scrubber = $mergedConfig['scrubber'];
+
+        $container->setParameter(
+            'lingoda_sentry.scrubber.query_param_names',
+            array_values(array_unique(array_merge(
+                $scrubber['query_param_names'],
+                $scrubber['extra_query_param_names'],
+            ))),
+        );
+        $container->setParameter(
+            'lingoda_sentry.scrubber.value_patterns',
+            array_values(array_unique(array_merge(
+                $scrubber['value_patterns'],
+                $scrubber['extra_value_patterns'],
+            ))),
+        );
     }
 
     public function prepend(ContainerBuilder $container): void
@@ -49,6 +68,18 @@ class LingodaSentryExtension extends ConfigurableExtension implements PrependExt
             $config['json_serialize'],
             ObjectJsonSerializer::class
         );
+
+        $beforeSend = $config['before_send'];
+        if ($beforeSend === null && $config['scrubber']['enabled'] === true) {
+            $beforeSend = SensitiveDataScrubber::class;
+        }
+        if ($beforeSend !== null) {
+            $sentryConfig['options']['before_send'] = $beforeSend;
+        }
+
+        if ($config['before_breadcrumb'] !== null) {
+            $sentryConfig['options']['before_breadcrumb'] = $config['before_breadcrumb'];
+        }
 
         $container->setParameter('lingoda_sentry.config', $config);
         $container->prependExtensionConfig('sentry', $sentryConfig);

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -18,6 +18,13 @@ services:
 
     Lingoda\SentryBundle\Sentry\Serializer\NamespaceJsonSerializer: ~
 
+    # Default before_send scrubber. Override by either decorating this service
+    # or by setting lingoda_sentry.before_send to your own service id.
+    Lingoda\SentryBundle\Sentry\SensitiveDataScrubber:
+        arguments:
+            $queryParamNames: '%lingoda_sentry.scrubber.query_param_names%'
+            $valuePatterns: '%lingoda_sentry.scrubber.value_patterns%'
+
     Monolog\Processor\PsrLogMessageProcessor:
         tags: { name: monolog.processor, handler: sentry }
 

--- a/src/Sentry/SensitiveDataScrubber.php
+++ b/src/Sentry/SensitiveDataScrubber.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lingoda\SentryBundle\Sentry;
+
+use Sentry\Breadcrumb;
+use Sentry\Event;
+use Sentry\EventHint;
+use Sentry\Stacktrace;
+
+/**
+ * Default `before_send` callback. Redacts well-known credential shapes from
+ * URLs, headers, exception messages, breadcrumbs and frame variables before
+ * the event reaches Sentry's servers.
+ *
+ * Designed to be overridden by consumers via Symfony service decoration:
+ * the class is non-final and the `scrub(string): string` entry point is
+ * public so decorators can reuse the string-level rules.
+ */
+class SensitiveDataScrubber
+{
+    public const string FILTERED = '[Filtered]';
+    private const int MAX_FRAME_VAR_DEPTH = 3;
+
+    /**
+     * @var list<string>
+     */
+    private array $valuePatterns;
+
+    private string $urlQueryRegex;
+
+    /**
+     * @param list<string> $queryParamNames
+     * @param list<string> $valuePatterns
+     */
+    public function __construct(
+        array $queryParamNames,
+        array $valuePatterns,
+    ) {
+        $this->validatePatterns($valuePatterns);
+        $this->valuePatterns = array_values($valuePatterns);
+        $this->urlQueryRegex = $this->buildUrlQueryRegex($this->normalizeNames($queryParamNames));
+    }
+
+    public function __invoke(Event $event, ?EventHint $hint = null): ?Event
+    {
+        $message = $event->getMessage();
+        if ($message !== null) {
+            $event->setMessage(
+                $this->scrub($message),
+                array_map(fn (string $p): string => $this->scrub($p), $event->getMessageParams()),
+                $this->scrubNullable($event->getMessageFormatted()),
+            );
+        }
+
+        $request = $event->getRequest();
+        if ($request !== []) {
+            $event->setRequest($this->scrubRequestArray($request));
+        }
+
+        $this->scrubExceptions($event);
+        $this->scrubBreadcrumbs($event);
+
+        $topStacktrace = $event->getStacktrace();
+        if ($topStacktrace !== null) {
+            $this->scrubStacktrace($topStacktrace);
+        }
+
+        return $event;
+    }
+
+    /**
+     * Apply URL-query and value-pattern scrubbing to a single string.
+     * Public so consumer decorators can reuse the rules.
+     */
+    public function scrub(string $value): string
+    {
+        return $this->scrubByPatterns($this->scrubUrlQuery($value));
+    }
+
+    private function scrubNullable(?string $value): ?string
+    {
+        return $value === null ? null : $this->scrub($value);
+    }
+
+    /**
+     * @param array<string, mixed> $request
+     *
+     * @return array<string, mixed>
+     */
+    private function scrubRequestArray(array $request): array
+    {
+        if (isset($request['url']) && is_string($request['url'])) {
+            $request['url'] = $this->scrub($request['url']);
+        }
+
+        if (isset($request['query_string']) && is_string($request['query_string'])) {
+            $request['query_string'] = $this->scrub($request['query_string']);
+        }
+
+        foreach (['headers', 'cookies', 'data', 'env'] as $key) {
+            if (isset($request[$key]) && is_array($request[$key])) {
+                $request[$key] = $this->scrubArrayRecursive($request[$key], 0);
+            }
+        }
+
+        return $request;
+    }
+
+    private function scrubExceptions(Event $event): void
+    {
+        foreach ($event->getExceptions() as $exception) {
+            $exception->setValue($this->scrub($exception->getValue()));
+
+            $stacktrace = $exception->getStacktrace();
+            if ($stacktrace !== null) {
+                $this->scrubStacktrace($stacktrace);
+            }
+        }
+    }
+
+    private function scrubBreadcrumbs(Event $event): void
+    {
+        $breadcrumbs = $event->getBreadcrumbs();
+        if ($breadcrumbs === []) {
+            return;
+        }
+
+        $event->setBreadcrumb(array_map(
+            fn (Breadcrumb $b): Breadcrumb => $this->scrubBreadcrumb($b),
+            $breadcrumbs,
+        ));
+    }
+
+    private function scrubBreadcrumb(Breadcrumb $breadcrumb): Breadcrumb
+    {
+        $message = $breadcrumb->getMessage();
+        if ($message !== null) {
+            $breadcrumb = $breadcrumb->withMessage($this->scrub($message));
+        }
+
+        foreach ($breadcrumb->getMetadata() as $key => $value) {
+            if (is_string($value)) {
+                $scrubbed = $this->scrub($value);
+                if ($scrubbed !== $value) {
+                    $breadcrumb = $breadcrumb->withMetadata($key, $scrubbed);
+                }
+            }
+        }
+
+        return $breadcrumb;
+    }
+
+    private function scrubStacktrace(Stacktrace $stacktrace): void
+    {
+        foreach ($stacktrace->getFrames() as $frame) {
+            $vars = $frame->getVars();
+            if ($vars === []) {
+                continue;
+            }
+            $frame->setVars($this->scrubArrayRecursive($vars, 0));
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $values
+     *
+     * @return array<array-key, mixed>
+     */
+    private function scrubArrayRecursive(array $values, int $depth): array
+    {
+        if ($depth >= self::MAX_FRAME_VAR_DEPTH) {
+            return $values;
+        }
+
+        foreach ($values as $key => $value) {
+            if (is_string($value)) {
+                $values[$key] = $this->scrub($value);
+            } elseif (is_array($value)) {
+                $values[$key] = $this->scrubArrayRecursive($value, $depth + 1);
+            }
+        }
+
+        return $values;
+    }
+
+    private function scrubUrlQuery(string $value): string
+    {
+        if ($this->urlQueryRegex === '') {
+            return $value;
+        }
+
+        $result = preg_replace_callback(
+            $this->urlQueryRegex,
+            /** @param array<int, string> $m */
+            static fn (array $m): string => $m[1] . $m[2] . '=' . self::FILTERED,
+            $value,
+        );
+
+        return $result ?? $value;
+    }
+
+    private function scrubByPatterns(string $value): string
+    {
+        foreach ($this->valuePatterns as $pattern) {
+            $result = preg_replace($pattern, self::FILTERED, $value);
+            if (is_string($result)) {
+                $value = $result;
+            }
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param list<string> $patterns
+     */
+    private function validatePatterns(array $patterns): void
+    {
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, '') === false) {
+                throw new \InvalidArgumentException(sprintf(
+                    'Invalid PCRE pattern in scrubber value_patterns: %s',
+                    $pattern,
+                ));
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $names
+     *
+     * @return list<string>
+     */
+    private function normalizeNames(array $names): array
+    {
+        return array_values(array_unique(array_map(
+            static fn (string $n): string => strtolower($n),
+            $names,
+        )));
+    }
+
+    /**
+     * @param list<string> $names
+     */
+    private function buildUrlQueryRegex(array $names): string
+    {
+        if ($names === []) {
+            return '';
+        }
+
+        $alternatives = implode('|', array_map(
+            static fn (string $n): string => preg_quote($n, '#'),
+            $names,
+        ));
+
+        // (prefix)(name)=(value-until-delimiter)
+        // prefix: start-of-string or `?` or `&`; value stops at `&`, `#`, whitespace, quote, `>`.
+        // The `#` inside the character class is escaped because we use `#` as the PCRE delimiter.
+        return '#(^|[?&])(' . $alternatives . ')=[^&\#\s"\'>]+#i';
+    }
+}

--- a/tests/config/reference.php
+++ b/tests/config/reference.php
@@ -718,7 +718,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *             sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *             server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *             default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *             sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *             sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *             sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -769,7 +769,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -801,7 +801,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *                 servicename?: scalar|Param|null, // Overrules dbname parameter if given and used as SERVICE_NAME or SID connection parameter for Oracle depending on the service parameter.
  *                 sessionMode?: scalar|Param|null, // The session mode to use for the oci8 driver
  *                 server?: scalar|Param|null, // The name of a running database server to connect to for SQL Anywhere.
- *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connexion.
+ *                 default_dbname?: scalar|Param|null, // Override the default database (postgres) to connect to for PostgreSQL connection.
  *                 sslmode?: scalar|Param|null, // Determines whether or with what priority a SSL TCP/IP connection will be negotiated with the server for PostgreSQL.
  *                 sslrootcert?: scalar|Param|null, // The name of a file containing SSL certificate authority (CA) certificate(s). If the file exists, the server's certificate will be verified to be signed by one of these authorities.
  *                 sslcert?: scalar|Param|null, // The path to the SSL client certificate file for PostgreSQL.
@@ -1152,8 +1152,17 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     namespace?: scalar|Param|null, // Default: null
  *     release?: scalar|Param|null, // Default: "none"
  *     traces_sample_rate?: float|Param, // Default: 0.0
+ *     before_send?: scalar|Param|null, // Service ID of a callable __invoke(Event, ?EventHint): ?Event. Overrides the default SensitiveDataScrubber. Mirror upstream sentry-symfony: no @ prefix. // Default: null
+ *     before_breadcrumb?: scalar|Param|null, // Service ID of a callable __invoke(Breadcrumb, ?BreadcrumbHint): ?Breadcrumb. No @ prefix. // Default: null
  *     json_serialize?: list<scalar|Param|null>,
  *     namespace_serialize?: list<scalar|Param|null>,
+ *     scrubber?: array{
+ *         enabled?: bool|Param, // Default: true
+ *         query_param_names?: list<scalar|Param|null>,
+ *         extra_query_param_names?: list<scalar|Param|null>,
+ *         value_patterns?: list<scalar|Param|null>,
+ *         extra_value_patterns?: list<scalar|Param|null>,
+ *     },
  * }
  * @psalm-type ConfigType = array{
  *     imports?: ImportsConfig,


### PR DESCRIPTION
Introduce a scrubber that will sanitize error data before sending to Sentry. As a first step, we scrub the most obvious sensitive data leaks, but it can be extended if needed.